### PR TITLE
Relax max attempts exception for unique items

### DIFF
--- a/src/Mock/Generation/Value/Composite/ArrayValueGenerator.php
+++ b/src/Mock/Generation/Value/Composite/ArrayValueGenerator.php
@@ -52,7 +52,16 @@ class ArrayValueGenerator implements ValueGeneratorInterface
         $valueGenerator = $this->generatorLocator->getValueGenerator($type->items);
 
         for ($i = 1; $i <= $count; $i++) {
-            $values[] = $this->generateArrayValue($valueGenerator, $type, $uniqueValues);
+            try {
+                $values[] = $this->generateArrayValue($valueGenerator, $type, $uniqueValues);
+            } catch (\RuntimeException $e) {
+                // Only throw attempts limit exception, of not enough values were generated
+                if (count($values) < ($type->minItems > 0 ? $type->minItems : self::DEFAULT_MIN_ITEMS)) {
+                    throw $e;
+                } else {
+                    break;
+                }
+            }
         }
 
         return $values;

--- a/tests/Unit/Mock/Generation/Value/Composite/ArrayValueGeneratorTest.php
+++ b/tests/Unit/Mock/Generation/Value/Composite/ArrayValueGeneratorTest.php
@@ -104,7 +104,25 @@ class ArrayValueGeneratorTest extends TestCase
     }
 
     /** @test */
-    public function generateValue_arrayTypeWithUniqueItems_exceptionThrownOnRetryLimit(): void
+    public function generateValue_arrayTypeWithUniqueItems_retryLimitExceededButMinItemsSatisfied(): void
+    {
+        $generator = $this->createArrayValueGenerator();
+        $type = new ArrayType();
+        $type->items = new DummyType();
+        $type->minItems = 1;
+        $type->maxItems = 3;
+        $type->uniqueItems = true;
+        $randomRangeValueGenerator = $this->givenRandomRangeValueGenerator(0, 1);
+        $this->givenValueGeneratorLocator_getValueGenerator_returnsValueGenerator($randomRangeValueGenerator);
+
+        $array = $generator->generateValue($type);
+
+        $this->assertGreaterThanOrEqual(1, count($array));
+        $this->assertLessThanOrEqual(3, count($array));
+    }
+
+    /** @test */
+    public function generateValue_arrayTypeWithUniqueItems_exceptionThrownOnRetryLimitAndNotSatisfyingMinItems(): void
     {
         $generator = $this->createArrayValueGenerator();
         $type = new ArrayType();


### PR DESCRIPTION
Only throw exception, if number of generated values is lower then the mininum specified. Prevent s'Cannot generate array with unique values, attempts limit exceeded' exception in ArrayValueGenerator to be thrown, if the number of generated items exceeds the minimum item count.