### PR TITLE
Handle CORS requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,12 @@ Mock server options can be set via environment variables.
 * _Default value_: `disabled`
 * _Possible values_: `disabled`, `url_md5`, `url_and_timestamp_md5`
 
+#### SWAGGER_MOCK_CORS_ENABLE
+
+ * When enabled, CORS request will automatically be handled
+ * _Default value_: `False`
+ * _Possible values_: `True` or `False`
+
 ### Specification cache
 
 To speed up server response time you can use caching mechanism for OpenAPI. There are several caching strategies. Specific strategy can be set by environment variable `SWAGGER_MOCK_CACHE_STRATEGY`.

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -3,6 +3,7 @@ parameters:
   env(SWAGGER_MOCK_CACHE_STRATEGY): 'disabled'
   env(SWAGGER_MOCK_CACHE_DIRECTORY): '/dev/shm/openapi-cache'
   env(SWAGGER_MOCK_CACHE_TTL): 0
+  env(SWAGGER_MOCK_CORS_ENABLE): False
 
   locale: 'en'
   specification_url: '%env(SWAGGER_MOCK_SPECIFICATION_URL)%'
@@ -10,6 +11,7 @@ parameters:
   cache_directory: '%env(SWAGGER_MOCK_CACHE_DIRECTORY)%'
   cache_ttl: '%env(SWAGGER_MOCK_CACHE_TTL)%'
   log_level: '%env(SWAGGER_MOCK_LOG_LEVEL)%'
+  cors_enable: '%env(SWAGGER_MOCK_CORS_ENABLE)%'
 
   type_parser_map:
     object: 'App\OpenAPI\Parsing\Type\Composite\ObjectTypeParser'
@@ -62,6 +64,12 @@ services:
   App\EventListener\RequestListener:
     tags:
       - { name: kernel.event_listener, event: kernel.request, priority: 48 }
+
+  App\EventListener\CorsResponseListener:
+    arguments:
+      - '%cors_enable%'
+    tags:
+      - { name: kernel.event_listener, event: kernel.response, priority: 46 }
 
   App\Mock\EndpointRepository:
     arguments:

--- a/src/EventListener/CorsResponseListener.php
+++ b/src/EventListener/CorsResponseListener.php
@@ -31,7 +31,6 @@ class CorsResponseListener
 
         $response = $event->getResponse();
 
-
         $response->headers->set('Access-Control-Allow-Origin', $request->headers->get('Origin'));
 
         $response->headers->set(

--- a/src/EventListener/CorsResponseListener.php
+++ b/src/EventListener/CorsResponseListener.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\EventListener;
+
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Event\ResponseEvent;
+
+class CorsResponseListener
+{
+    /** @var bool */
+    private $cors_enable;
+
+    public function __construct(bool $cors_enable)
+    {
+        $this->cors_enable = $cors_enable;
+    }
+
+    public function onKernelResponse(ResponseEvent $event): void
+    {
+        if (!$this->cors_enable) {
+            return;
+        }
+
+        $request = $event->getRequest();
+
+        if (!$request->isMethod('OPTIONS')) {
+            return;
+        }
+
+        $response = $event->getResponse();
+
+        if ($response->getStatusCode() !== Response::HTTP_NOT_FOUND) {
+            return;
+        }
+
+        $response->headers->set('Access-Control-Allow-Origin', $request->headers->get('Origin', '*'));
+
+        $response->headers->set(
+            'Access-Control-Allow-Methods',
+            $request->headers->get('Access-Control-Request-Method', 'GET,POST,PUT,DELETE')
+        );
+
+        if ($requestHeaders = $request->headers->get('Access-Control-Request-Headers')) {
+            $response->headers->set('Access-Control-Allow-Headers', $requestHeaders);
+        }
+
+        $response->setContent('');
+        $response->setStatusCode(Response::HTTP_NO_CONTENT);
+    }
+}

--- a/src/EventListener/CorsResponseListener.php
+++ b/src/EventListener/CorsResponseListener.php
@@ -25,17 +25,14 @@ class CorsResponseListener
 
         $request = $event->getRequest();
 
-        if (!$request->isMethod('OPTIONS')) {
+        if (!$request->headers->has('Origin')) {
             return;
         }
 
         $response = $event->getResponse();
 
-        if ($response->getStatusCode() !== Response::HTTP_NOT_FOUND) {
-            return;
-        }
 
-        $response->headers->set('Access-Control-Allow-Origin', $request->headers->get('Origin', '*'));
+        $response->headers->set('Access-Control-Allow-Origin', $request->headers->get('Origin'));
 
         $response->headers->set(
             'Access-Control-Allow-Methods',
@@ -46,7 +43,11 @@ class CorsResponseListener
             $response->headers->set('Access-Control-Allow-Headers', $requestHeaders);
         }
 
-        $response->setContent('');
-        $response->setStatusCode(Response::HTTP_NO_CONTENT);
+        if ($request->isMethod('OPTIONS')) {
+            if ($response->getStatusCode() === Response::HTTP_NOT_FOUND) {
+                $response->setContent('');
+                $response->setStatusCode(Response::HTTP_NO_CONTENT);
+            }
+        }
     }
 }

--- a/tests/Unit/EventListener/CorsResponseListenerTest.php
+++ b/tests/Unit/EventListener/CorsResponseListenerTest.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\EventListener;
+
+use App\EventListener\CorsResponseListener;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Event\ResponseEvent;
+
+class CorsResponseListenerTest extends TestCase
+{
+    /** @var ResponseEvent */
+    private $event;
+
+    protected function setUp(): void
+    {
+        $this->event = \Phake::mock(ResponseEvent::class);
+    }
+
+    /** @test */
+    public function onUnhandledCorsRequest_ifFeatureEnabled_handlesCors(): void
+    {
+        $listener = new CorsResponseListener(true);
+        $request = new Request();
+        $request->setMethod('OPTIONS');
+        $response = new Response();
+        $response->setStatusCode(Response::HTTP_NOT_FOUND);
+        \Phake::when($this->event)
+            ->getRequest()
+            ->thenReturn($request);
+        \Phake::when($this->event)
+            ->getResponse()
+            ->thenReturn($response);
+
+        $listener->onKernelResponse($this->event);
+
+        $this->assertEquals(Response::HTTP_NO_CONTENT, $response->getStatusCode());
+        $this->assertEquals('*', $response->headers->get('Access-Control-Allow-Origin'));
+        $this->assertEquals('GET,POST,PUT,DELETE', $response->headers->get('Access-Control-Allow-Methods'));
+        $this->assertEquals('', $response->getContent());
+    }
+
+    /** @test */
+    public function onHandledCorsRequest_ifFeatureEnabled_doesNothing(): void
+    {
+        $listener = new CorsResponseListener(true);
+        $request = new Request();
+        $request->setMethod('OPTIONS');
+        $response = new Response();
+        $response->setStatusCode(Response::HTTP_OK);
+        $response->setContent('something');
+        \Phake::when($this->event)
+            ->getRequest()
+            ->thenReturn($request);
+        \Phake::when($this->event)
+            ->getResponse()
+            ->thenReturn($response);
+
+        $listener->onKernelResponse($this->event);
+
+        $this->assertEquals(Response::HTTP_OK, $response->getStatusCode());
+        $this->assertEquals('something', $response->getContent());
+        $this->assertEquals('', $response->headers->get('Access-Control-Allow-Origin'));
+        $this->assertEquals('', $response->headers->get('Access-Control-Allow-Methods'));
+    }
+
+    /** @test */
+    public function onUnhandledCorsRequest_ifFeatureDisabled_doesNothing(): void
+    {
+        $listener = new CorsResponseListener(false);
+        $request = new Request();
+        $request->setMethod('OPTIONS');
+        $response = new Response();
+        $response->setStatusCode(Response::HTTP_NOT_FOUND);
+        \Phake::when($this->event)
+            ->getRequest()
+            ->thenReturn($request);
+        \Phake::when($this->event)
+            ->getResponse()
+            ->thenReturn($response);
+
+        $listener->onKernelResponse($this->event);
+
+        $this->assertEquals(Response::HTTP_NOT_FOUND, $response->getStatusCode());
+        $this->assertEquals('', $response->headers->get('Access-Control-Allow-Origin'));
+        $this->assertEquals('', $response->headers->get('Access-Control-Allow-Methods'));
+    }
+}


### PR DESCRIPTION
closes #34

if `SWAGGER_MOCK_CORS_ENABLE` is set to `True` CORS request will be handled.


Sorry, I recreated the MR because the previous one fails the pipeline because I did a push force.